### PR TITLE
added short inter estrus

### DIFF
--- a/bovheat_src/bovheat.py
+++ b/bovheat_src/bovheat.py
@@ -118,7 +118,7 @@ def cut_time_window(cowdf, start_dim, stop_dim):
 
 
 def calc_heats(cowdf, threshold):
-    # ToDo: Implement peaks-touching
+    MINIMUM_HOURS_APART = 10
 
     act_usable = cowdf["Activity Change"].count() / (len(cowdf)) * 100
     cowdf.reset_index(drop=True, inplace=True)
@@ -136,7 +136,7 @@ def calc_heats(cowdf, threshold):
             "max_act_heat",
             "max_dim_heat",
             "max_dt_heat",
-            "abnormal_flag",
+            "short_inter_estrus",
         ]
     )
 
@@ -166,11 +166,14 @@ def calc_heats(cowdf, threshold):
         heat_df.loc[index, "max_dim_heat"] = max_dim_heat
         heat_df.loc[index, "max_dt_heat"] = max_dt_heat
 
+        if index > 0:
+            if (heat_group[0] - peak_groups[index - 1][-1]) * 2 < MINIMUM_HOURS_APART:
+                heat_df.loc[index, "short_inter_estrus"] = 1
+
     heat_df["calving_date"] = cowdf["calving_date"].iloc[0]
     heat_df["heat_count"] = heat_df["heat_no"].nunique()
     heat_df["act_usable"] = act_usable
     heat_df["act_max"] = heat_df["max_act_heat"].max()
-    heat_df["abnormal_flag"] = None
 
     return heat_df
 

--- a/tests/test_peakcalculation.py
+++ b/tests/test_peakcalculation.py
@@ -8,7 +8,7 @@ class TestBovHeat(unittest.TestCase):
     def test_peakcalculation(self):
         # Unit Test Peak Calculation
         input_data = {
-            "Activity Change": [5, 11, 11, 36, 11, 11, 5, 25, 44, 66, 55, 44, 4, 2, 2],
+            "Activity Change": [5, 11, 11, 36, 35, 11, 5, 25, 44, 66, 55, 44, 4, 2, 2],
             "Days in Lactation": [0, 2, 4, 6, 8, 10, 12, 14, 16, 18, 20, 22, 24, 0, 2],
             "datetime": pd.date_range("2015-02-24 00:00:00", periods=15, freq="2H"),
             "calving_date": [pd.to_datetime("2015-02-20 00:00:00")] * 15,
@@ -19,11 +19,12 @@ class TestBovHeat(unittest.TestCase):
             dict(
                 heat_no=1,
                 start_dt_heat=pd.to_datetime("2015-02-24 06:00:00"),
-                stop_dt_heat=pd.to_datetime("2015-02-24 06:00:00"),
-                duration_heat=2,
+                stop_dt_heat=pd.to_datetime("2015-02-24 08:00:00"),
+                duration_heat=4,
                 max_act_heat=36,
                 max_dim_heat=6,
                 max_dt_heat=pd.to_datetime("2015-02-24 06:00:00"),
+                short_inter_estrus=None,
             ),
             dict(
                 heat_no=2,
@@ -33,6 +34,7 @@ class TestBovHeat(unittest.TestCase):
                 max_act_heat=66,
                 max_dim_heat=18,
                 max_dt_heat=pd.to_datetime("2015-02-24 18:00:00"),
+                short_inter_estrus=1,
             ),
         ]
         expected_df = pd.DataFrame(data=expected_data)
@@ -49,6 +51,7 @@ class TestBovHeat(unittest.TestCase):
                     "max_act_heat",
                     "max_dim_heat",
                     "max_dt_heat",
+                    "short_inter_estrus",
                 ]
             ],
             expected_df,


### PR DESCRIPTION
Closes #6 was the focus for now.
But open for ideas to make the now provided short inter-estrus information more usable.
Maybe the final goal is to scrap it completely and to combine these estrus events into one.
Controlled by a provided minimum_hours_apart start flag.

