### PR TITLE
lower ubuntu version for backwards compatibility

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -57,7 +57,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: ["ubuntu-18.04", windows-latest, macos-latest]
         python-version: [3.8] #3.7, 3.8
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Lowered the Ubuntu version for the Linux runner as the ensuing GLIBC >=2.29 hinders backwards compatibility.